### PR TITLE
sidebars show officer and deputies

### DIFF
--- a/_includes/officer-for-sidebar.html
+++ b/_includes/officer-for-sidebar.html
@@ -1,28 +1,40 @@
-{% if officer %}
+{% assign officers = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", include.office | sort: 'responsibility' %}
+{% assign numofficers = officers|size %}
+{% assign role = site.data.officetitles | where:"slug", include.office | first %}
 
-{% assign role = site.data.officetitles | where:"slug", officer.office | first %}
+{% if numofficers > 0 %}
 
-<h3>{{ role.title }}</h3>
-<p><strong>{{ officer.scaname }}</strong>
-{% unless officer.mundanename == "" %}
- ({{ officer.mundanename }})
-{% endunless %}
-{% unless officer.pronouns == "" %}
- <span class="text-muted">{{ officer.pronouns }}</span>
-{% endunless %}<br>
-<strong>Contact:</strong> {{ officer.email }}
-</p>
+  <h3>{{ role.title }}</h3>
+
+  {% for officer in officers %}
+
+    {% unless officer.responsibility == " " %}
+    <h6>{{officer.responsibility}}</h6>
+    {% endunless %}
+    <p><strong>{{ officer.scaname }}</strong>
+    {% unless officer.mundanename == "" %}
+     ({{ officer.mundanename }})
+    {% endunless %}
+    {% unless officer.pronouns == "" %}
+     <span class="text-muted">{{ officer.pronouns }}</span>
+    {% endunless %}<br>
+    {% unless officer.email == "" %}
+      <strong>Contact:</strong> {{ officer.email }}
+    {% endunless %}
+    </p>
+
+  {% endfor %}
+
+{% else %}
+
+  <span><em>Officer details to come</em></span>
+
+{% endif %}
 
 {% if role.report %}<p><a href="{{ role.report }}">How to report</a></p>{% endif %}
 
 {% if role.desc %}
-<p>
-{{ role.desc }}
-</p>
-{% endif %}
-
-{% else %}
-
-<span><em>Officer details to come</em></span>
-
+  <p>
+  {{ role.desc }}
+  </p>
 {% endif %}

--- a/_includes/sidebar-aands.html
+++ b/_includes/sidebar-aands.html
@@ -1,7 +1,6 @@
 											<section>
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "moas" | last %}
 
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="moas" %}
 
 <hr />
 

--- a/_includes/sidebar-archery.html
+++ b/_includes/sidebar-archery.html
@@ -1,7 +1,6 @@
 <section>
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "archery-thrown-marshal" | last %}
 
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="archery-thrown-marshal" %}
 
 <hr />
 

--- a/_includes/sidebar-armouredcombat.html
+++ b/_includes/sidebar-armouredcombat.html
@@ -1,6 +1,5 @@
 <section>
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "armoured-combat-marshal" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html  office="armoured-combat-marshal" %}
 
 <hr>
 

--- a/_includes/sidebar-castellan.html
+++ b/_includes/sidebar-castellan.html
@@ -1,7 +1,6 @@
   <section>
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "chatelaine" | last %}
 
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html  office="chatelaine" %}
 
 <hr />
 

--- a/_includes/sidebar-chronicler.html
+++ b/_includes/sidebar-chronicler.html
@@ -1,2 +1,1 @@
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "chronicler" | where:"role_type", "officer" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="chronicler" %}

--- a/_includes/sidebar-groups.html
+++ b/_includes/sidebar-groups.html
@@ -1,13 +1,11 @@
 <section>
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "seneschal" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="seneschal" %}
      
 </section>
 <hr />
 <section>
 
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "exchequer" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="exchequer" %}
 
 <br>
 

--- a/_includes/sidebar-herald.html
+++ b/_includes/sidebar-herald.html
@@ -1,2 +1,1 @@
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "herald" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="herald" %}

--- a/_includes/sidebar-rapier.html
+++ b/_includes/sidebar-rapier.html
@@ -1,5 +1,4 @@
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "fencing-marshal" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="fencing-marshal" %}
 
 <hr />
 

--- a/_includes/sidebar-scribal.html
+++ b/_includes/sidebar-scribal.html
@@ -1,2 +1,1 @@
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "signet" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="signet" %}

--- a/_includes/sidebar-webminister.html
+++ b/_includes/sidebar-webminister.html
@@ -1,2 +1,1 @@
-{% assign officer = site.data.regnum | where:"group", "Insulae Draconis" | where:"office", "webminister" | last %}
-{% include officer-for-sidebar.html %}
+{% include officer-for-sidebar.html office="webminister" %}

--- a/activities/index.html
+++ b/activities/index.html
@@ -186,7 +186,7 @@ banner: /images/banner/drimnaghcastle.jpg
       Fencing is the perfect way to study, replicate and compete with styles of light, heavy and cut-and-thrust weapon sword-fighting found in Europe during the Renaissance period.  This is not fencing in the Olympic style, this is based on ever expanding avenues of research with actual historical manuals.  It is an exciting, fast sport with plenty of style - fighter fight in period clothes - where fighters use blunted steel swords and a variety of off-hand defensive items.  Want to find out just how historically correct your favourite fight scene from a movie is? We have people who can tell you, and recommend texts to recreate your favourite fight more authentically!  
     </p>
 
-    <a href="https://insulaedraconis.org/activities/rapier/" class="btn btn-primary">More about fencing...</a>
+    <a href="/activities/rapier/" class="btn btn-primary">More about fencing...</a>
 
   </div>
 </div>

--- a/library/index.md
+++ b/library/index.md
@@ -6,21 +6,21 @@ banner: /images/banner/scribalDeskTretower.jpg
 
 # Governance
 
-- [Principality Law - PDF](https://insulaedraconis.org/library/publications/ID_Law.pdf)
+- [Principality Law - PDF](/library/publications/ID_Law.pdf)
 - [Principality financial policies](https://docs.google.com/document/d/1OhTXWCqVpGz38tjbRbmbomcxuLpymnMOY-LnzZ4k4kE/edit)
-- [Principality Inclusivity Statement](https://insulaedraconis.org/governance/inclusivity-statement/)
+- [Principality Inclusivity Statement](/governance/inclusivity-statement/)
 - [Drachenwald Code of Conduct](https://drachenwald.sca.org/offices/seneschal/files/DrachenwaldCodeofConductv1.0June2020.pdf)
 - [Conduct and behaviour resources](https://www.sca.org/conduct-behavior-in-the-sca/) at sca.org
 - Guild Charters
-  - [Fibre Guild Charter](https://insulaedraconis.org/library/charters/fibre-guild-charter/)
-- [GDPR](https://insulaedraconis.org/governance/gdpr/)
-- [General GDPR advice and key changes](https://insulaedraconis.org/governance/gdpr-advice/)
+  - [Fibre Guild Charter](/library/charters/fibre-guild-charter/)
+- [GDPR](/governance/gdpr/)
+- [General GDPR advice and key changes](/governance/gdpr-advice/)
 - [About the UK CIC Board and officers](https://www.aspiringluddite.com/sca/CICsum.shtml)
 - [Get or renew your membership](https://membermojo.co.uk/scauk)
 
 # Group resources
 
-- [Tools for building and organising a local group](https://insulaedraconis.org/library/group-resources/)
+- [Tools for building and organising a local group](/library/group-resources/)
 
 # Event resources
 
@@ -40,7 +40,7 @@ banner: /images/banner/scribalDeskTretower.jpg
 - [Meet the Chatelaine (responsible for helping newcomers)]({% link newcomers/chatelaine.md %})
 - [What to expect at your first event]({% link newcomers/what-to-expect.md %})
 - [Jargon buster]({% link newcomers/jargonbuster.md %})
-- [Introduction to heraldry](https://insulaedraconis.org/activities/heraldry/before-the-internet/)
+- [Introduction to heraldry](/activities/heraldry/before-the-internet/)
 - [Why I joined: our members share their stories]({% link newcomers/why-i-joined.md %})
 - [What is Court and what is expected of me?]({% link coronet/what-is-court.md %})
 - [What do people mean when they say Recommend someone for an award?]({% link activities/heraldry/awards.md %})
@@ -55,22 +55,22 @@ banner: /images/banner/scribalDeskTretower.jpg
 
 - [Insulae Draconis Book of Ceremonies](https://insulaedraconis.gitlab.io/ceremonies/)
   - [Book of Ceremonies source repository](https://gitlab.com/insulaedraconis/ceremonies)
-- [Heraldry in the SCA](https://insulaedraconis.org/library/howtos/heraldry-in-sca/)
-- [Court and Tourney Heraldry](https://insulaedraconis.org/library/howtos/court-and-tourney-heraldry/)
+- [Heraldry in the SCA](/library/howtos/heraldry-in-sca/)
+- [Court and Tourney Heraldry](/library/howtos/court-and-tourney-heraldry/)
 - [How to submit a name or device](https://drachenwald.sca.org/offices/herald/submittingnamesheraldry/)
-- [Insulae Draconis awards](https://insulaedraconis.org/activities/heraldry/awards/)
+- [Insulae Draconis awards](/activities/heraldry/awards/)
 
 # History
 
-- [Previous reigns](https://insulaedraconis.org/coronet/past/)
-- [Previous Principality protectors](https://insulaedraconis.org/activities/protectors/)
-- [Founding Order members](https://insulaedraconis.org/activities/heraldry/founding-members/)
+- [Previous reigns](/coronet/past/)
+- [Previous Principality protectors](/activities/protectors/)
+- [Founding Order members](/activities/heraldry/founding-members/)
 
 # How-tos, and other miscellany
 
 - [Personas]({% link library/howtos/adopt-a-persona.md %})
-- [Make a war tabard](https://insulaedraconis.org/activities/heraldry/id-tabard/)
-- [Insulae Draconis war standard design](https://insulaedraconis.org/activities/heraldry/id-banner/)
-- [Charted heraldic patterns](https://insulaedraconis.org/activities/heraldry/cross-stitch/)
+- [Make a war tabard](/activities/heraldry/id-tabard/)
+- [Insulae Draconis war standard design](/activities/heraldry/id-banner/)
+- [Charted heraldic patterns](/activities/heraldry/cross-stitch/)
 
 


### PR DESCRIPTION
There is a bug in the code that shows officer info in the sidebars; it was only showing one officer, and sometimes that could be a deputy instead of the actual sitting officer. This pull request changes it so that it shows the officer and deputies, in the same way that the contacts page does.